### PR TITLE
Fix/#4: design system

### DIFF
--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -54,7 +54,7 @@ final class OrmeeColor extends Color {
     20: Color(0xFF00B3FF),
   };
 
-  static const Map<int, double> opacity = {
+  static const Map<int, double> opacityLevel = {
     90: 0.9,
     80: 0.8,
     70: 0.7,

--- a/lib/core/theme/app_fonts.dart
+++ b/lib/core/theme/app_fonts.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'lib/core/theme/app_colors.dart';
+import 'package:ormee_app/core/theme/app_colors.dart';
 
 /// 폰트 굵기 매핑
 /// Bold = w700, SemiBold = w600, Medium = w500, Regular = w400
@@ -11,25 +11,25 @@ class Display1Bold56 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Display1Bold56({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w700,
-          fontSize: 56,
-          height: 1.4,
-          letterSpacing: -0.02 * 56,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w700,
+      fontSize: 56,
+      height: 1.4,
+      letterSpacing: -0.02 * 56,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Display1SemiBold56 extends StatelessWidget {
@@ -38,25 +38,25 @@ class Display1SemiBold56 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Display1SemiBold56({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w600,
-          fontSize: 56,
-          height: 1.4,
-          letterSpacing: -0.02 * 56,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w600,
+      fontSize: 56,
+      height: 1.4,
+      letterSpacing: -0.02 * 56,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Display1Regular56 extends StatelessWidget {
@@ -65,25 +65,25 @@ class Display1Regular56 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Display1Regular56({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 56,
-          height: 1.4,
-          letterSpacing: -0.02 * 56,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 56,
+      height: 1.4,
+      letterSpacing: -0.02 * 56,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Display 2 (40px) ---
@@ -93,25 +93,25 @@ class Display2Bold40 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Display2Bold40({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w700,
-          fontSize: 40,
-          height: 1.4,
-          letterSpacing: -0.02 * 40,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w700,
+      fontSize: 40,
+      height: 1.4,
+      letterSpacing: -0.02 * 40,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Display2SemiBold40 extends StatelessWidget {
@@ -120,25 +120,25 @@ class Display2SemiBold40 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Display2SemiBold40({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w600,
-          fontSize: 40,
-          height: 1.4,
-          letterSpacing: -0.02 * 40,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w600,
+      fontSize: 40,
+      height: 1.4,
+      letterSpacing: -0.02 * 40,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Display2Regular40 extends StatelessWidget {
@@ -147,25 +147,25 @@ class Display2Regular40 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Display2Regular40({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 40,
-          height: 1.4,
-          letterSpacing: -0.02 * 40,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 40,
+      height: 1.4,
+      letterSpacing: -0.02 * 40,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Title 1 (28px) ---
@@ -175,25 +175,25 @@ class Title1Bold28 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Title1Bold28({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w700,
-          fontSize: 28,
-          height: 1.4,
-          letterSpacing: -0.02 * 28,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w700,
+      fontSize: 28,
+      height: 1.4,
+      letterSpacing: -0.02 * 28,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Title1SemiBold28 extends StatelessWidget {
@@ -202,25 +202,25 @@ class Title1SemiBold28 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Title1SemiBold28({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w600,
-          fontSize: 28,
-          height: 1.4,
-          letterSpacing: -0.02 * 28,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w600,
+      fontSize: 28,
+      height: 1.4,
+      letterSpacing: -0.02 * 28,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Title1Regular28 extends StatelessWidget {
@@ -229,25 +229,25 @@ class Title1Regular28 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Title1Regular28({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 28,
-          height: 1.4,
-          letterSpacing: -0.02 * 28,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 28,
+      height: 1.4,
+      letterSpacing: -0.02 * 28,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Title 2 (26px) ---
@@ -257,25 +257,25 @@ class Title2Bold26 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Title2Bold26({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w700,
-          fontSize: 26,
-          height: 1.4,
-          letterSpacing: -0.02 * 26,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w700,
+      fontSize: 26,
+      height: 1.4,
+      letterSpacing: -0.02 * 26,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Title2SemiBold26 extends StatelessWidget {
@@ -284,25 +284,25 @@ class Title2SemiBold26 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Title2SemiBold26({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w600,
-          fontSize: 26,
-          height: 1.4,
-          letterSpacing: -0.02 * 26,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w600,
+      fontSize: 26,
+      height: 1.4,
+      letterSpacing: -0.02 * 26,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Title2Regular26 extends StatelessWidget {
@@ -311,25 +311,25 @@ class Title2Regular26 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Title2Regular26({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 26,
-          height: 1.4,
-          letterSpacing: -0.02 * 26,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 26,
+      height: 1.4,
+      letterSpacing: -0.02 * 26,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Title 3 (24px) ---
@@ -339,25 +339,25 @@ class Title3Bold24 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Title3Bold24({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w700,
-          fontSize: 24,
-          height: 1.4,
-          letterSpacing: -0.02 * 24,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w700,
+      fontSize: 24,
+      height: 1.4,
+      letterSpacing: -0.02 * 24,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Title3SemiBold24 extends StatelessWidget {
@@ -366,25 +366,25 @@ class Title3SemiBold24 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Title3SemiBold24({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w600,
-          fontSize: 24,
-          height: 1.4,
-          letterSpacing: -0.02 * 24,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w600,
+      fontSize: 24,
+      height: 1.4,
+      letterSpacing: -0.02 * 24,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Title3Regular24 extends StatelessWidget {
@@ -393,25 +393,25 @@ class Title3Regular24 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Title3Regular24({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 24,
-          height: 1.4,
-          letterSpacing: -0.02 * 24,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 24,
+      height: 1.4,
+      letterSpacing: -0.02 * 24,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Heading 1 (22px) ---
@@ -421,25 +421,25 @@ class Heading1Bold22 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Heading1Bold22({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w700,
-          fontSize: 22,
-          height: 1.4,
-          letterSpacing: -0.02 * 22,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w700,
+      fontSize: 22,
+      height: 1.4,
+      letterSpacing: -0.02 * 22,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Heading1SemiBold22 extends StatelessWidget {
@@ -448,25 +448,25 @@ class Heading1SemiBold22 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Heading1SemiBold22({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w600,
-          fontSize: 22,
-          height: 1.4,
-          letterSpacing: -0.02 * 22,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w600,
+      fontSize: 22,
+      height: 1.4,
+      letterSpacing: -0.02 * 22,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Heading1Regular22 extends StatelessWidget {
@@ -475,25 +475,25 @@ class Heading1Regular22 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Heading1Regular22({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 22,
-          height: 1.4,
-          letterSpacing: -0.02 * 22,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 22,
+      height: 1.4,
+      letterSpacing: -0.02 * 22,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Heading 2 (20px) ---
@@ -503,25 +503,25 @@ class Heading2Bold20 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Heading2Bold20({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w700,
-          fontSize: 20,
-          height: 1.4,
-          letterSpacing: -0.02 * 20,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w700,
+      fontSize: 20,
+      height: 1.4,
+      letterSpacing: -0.02 * 20,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Heading2SemiBold20 extends StatelessWidget {
@@ -530,25 +530,25 @@ class Heading2SemiBold20 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Heading2SemiBold20({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w600,
-          fontSize: 20,
-          height: 1.4,
-          letterSpacing: -0.02 * 20,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w600,
+      fontSize: 20,
+      height: 1.4,
+      letterSpacing: -0.02 * 20,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Heading2Regular20 extends StatelessWidget {
@@ -557,25 +557,25 @@ class Heading2Regular20 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Heading2Regular20({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 20,
-          height: 1.4,
-          letterSpacing: -0.02 * 20,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 20,
+      height: 1.4,
+      letterSpacing: -0.02 * 20,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Headline 1 (18px) ---
@@ -585,25 +585,25 @@ class Headline1Bold18 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Headline1Bold18({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w700,
-          fontSize: 18,
-          height: 1.4,
-          letterSpacing: -0.02 * 18,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w700,
+      fontSize: 18,
+      height: 1.4,
+      letterSpacing: -0.02 * 18,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Headline1SemiBold18 extends StatelessWidget {
@@ -612,25 +612,25 @@ class Headline1SemiBold18 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Headline1SemiBold18({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w600,
-          fontSize: 18,
-          height: 1.4,
-          letterSpacing: -0.02 * 18,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w600,
+      fontSize: 18,
+      height: 1.4,
+      letterSpacing: -0.02 * 18,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Headline1Regular18 extends StatelessWidget {
@@ -639,25 +639,25 @@ class Headline1Regular18 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Headline1Regular18({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 18,
-          height: 1.4,
-          letterSpacing: -0.02 * 18,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 18,
+      height: 1.4,
+      letterSpacing: -0.02 * 18,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Headline 2 (16px) ---
@@ -667,25 +667,25 @@ class Headline2Bold16 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Headline2Bold16({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w700,
-          fontSize: 16,
-          height: 1.4,
-          letterSpacing: -0.02 * 16,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w700,
+      fontSize: 16,
+      height: 1.4,
+      letterSpacing: -0.02 * 16,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Headline2SemiBold16 extends StatelessWidget {
@@ -694,25 +694,25 @@ class Headline2SemiBold16 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Headline2SemiBold16({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w600,
-          fontSize: 16,
-          height: 1.4,
-          letterSpacing: -0.02 * 16,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w600,
+      fontSize: 16,
+      height: 1.4,
+      letterSpacing: -0.02 * 16,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 class Headline2Regular16 extends StatelessWidget {
@@ -721,25 +721,25 @@ class Headline2Regular16 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Headline2Regular16({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 16,
-          height: 1.4,
-          letterSpacing: -0.02 * 16,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 16,
+      height: 1.4,
+      letterSpacing: -0.02 * 16,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Body 1 ---
@@ -750,25 +750,25 @@ class Body1RegularNormal16 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Body1RegularNormal16({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 16,
-          height: 1.4,
-          letterSpacing: -0.02 * 16,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 16,
+      height: 1.4,
+      letterSpacing: -0.02 * 16,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // Regular reading 16px (lineHeight 155%)
@@ -778,25 +778,25 @@ class Body1RegularReading16 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Body1RegularReading16({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 16,
-          height: 1.55,
-          letterSpacing: -0.02 * 16,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 16,
+      height: 1.55,
+      letterSpacing: -0.02 * 16,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Body 2 ---
@@ -807,25 +807,25 @@ class Body2RegularNormal14 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Body2RegularNormal14({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 14,
-          height: 1.4,
-          letterSpacing: -0.02 * 14,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 14,
+      height: 1.4,
+      letterSpacing: -0.02 * 14,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // Regular reading 14px (lineHeight 150%)
@@ -835,25 +835,25 @@ class Body2RegularReading14 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Body2RegularReading14({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 14,
-          height: 1.5,
-          letterSpacing: -0.02 * 14,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 14,
+      height: 1.5,
+      letterSpacing: -0.02 * 14,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Label 1 (Medium 14px) ---
@@ -863,25 +863,25 @@ class Label1Medium14 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Label1Medium14({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w500, // Medium
-          fontSize: 14,
-          height: 1.4,
-          letterSpacing: -0.02 * 14,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w500, // Medium
+      fontSize: 14,
+      height: 1.4,
+      letterSpacing: -0.02 * 14,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Label 2 (Regular 12px) ---
@@ -891,25 +891,25 @@ class Label2Regular12 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Label2Regular12({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 12,
-          height: 1.4,
-          letterSpacing: -0.02 * 12,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 12,
+      height: 1.4,
+      letterSpacing: -0.02 * 12,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // Regular reading 12px
@@ -919,25 +919,25 @@ class Label2RegularReading12 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Label2RegularReading12({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 12,
-          height: 1.4,
-          letterSpacing: -0.02 * 12,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 12,
+      height: 1.4,
+      letterSpacing: -0.02 * 12,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Caption 1 (11px) ---
@@ -947,25 +947,25 @@ class Caption1Regular11 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Caption1Regular11({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 11,
-          height: 1.4,
-          letterSpacing: -0.02 * 11,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 11,
+      height: 1.4,
+      letterSpacing: -0.02 * 11,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }
 
 // --- Caption 2 (10px) ---
@@ -975,23 +975,23 @@ class Caption2Regular10 extends StatelessWidget {
   final TextOverflow? overflow;
 
   const Caption2Regular10({
-    Key? key,
+    super.key,
     required this.text,
     this.color,
     this.overflow,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => Text(
-        text,
-        style: TextStyle(
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w400,
-          fontSize: 10,
-          height: 1.4,
-          letterSpacing: -0.02 * 10,
-          color: color ?? OrmeeColor.black,
-        ),
-        overflow: overflow ?? TextOverflow.clip,
-      );
+    text,
+    style: TextStyle(
+      fontFamily: 'Pretendard',
+      fontWeight: FontWeight.w400,
+      fontSize: 10,
+      height: 1.4,
+      letterSpacing: -0.02 * 10,
+      color: color ?? OrmeeColor.black,
+    ),
+    overflow: overflow ?? TextOverflow.clip,
+  );
 }


### PR DESCRIPTION
OrmeeColor 클래스 내 static opacity 멤버명 변경으로 Color 클래스 인스턴스 멤버와 이름 충돌 해결
상대경로 import → package:ormee_app/core/theme/app_colors.dart로 변경
key 파라미터를 super parameter로 변환해 Dart 경고(use_super_parameters) 해결